### PR TITLE
Removed xml data where it prevent parsing

### DIFF
--- a/models/iris_with_ardupilot/model.sdf
+++ b/models/iris_with_ardupilot/model.sdf
@@ -1,5 +1,5 @@
 <?xml version='1.0'?>
-<sdf version="1.6" xmlns:xacro='http://ros.org/wiki/xacro'>
+<sdf version="1.6">
   <model name="iris_demo">
     <include>
       <uri>model://iris_with_standoffs</uri>


### PR DESCRIPTION
`xmlns:xacro='http://ros.org/wiki/xacro'` will cause gazebo not to render the model in gazebo 11.